### PR TITLE
Clear link's title attribute wih undesirable characters.

### DIFF
--- a/Test/Case/View/Helper/MenuBuilderHelperTest.php
+++ b/Test/Case/View/Helper/MenuBuilderHelperTest.php
@@ -1113,4 +1113,30 @@ class MenuBuilderHelperTest extends CakeTestCase {
 		$this->assertTags($result, $expected, true);
 	}
 
+/**
+ * testSanitizeOfLinkTitle Test clearing link title attribute of undesirable characters
+ *
+ * @return void
+ */
+	public function testSanitizeOfLinkTitle() {
+		$menu = array(
+			array(
+				'title' => 'Item 1',
+				'url' => '/item-1'
+			),
+			array(
+				'title' => 'Item 2&nbsp;<i class="fa fa-caret-right"></i>',
+				'url' => '/item-2'
+			)
+		);
+		$result = $this->MenuBuilder->build(null, array(), $menu);
+		$expected = array(
+			'<ul',
+				array('li' => array('class' => 'first-item')), array('a' => array('href' => '/item-1', 'title' => 'Item 1')), 'Item 1', '</a', '</li',
+				'<li', array('a' => array('href' => '/item-2', 'title' => 'Item 2')), 'Item 2&amp;nbsp;&lt;i class=&quot;fa fa-caret-right&quot;&gt;&lt;/i&gt;', '</a', '</li',
+			'</ul'
+		);
+		$this->assertTags($result, $expected, true);
+	}
+
 }

--- a/View/Helper/MenuBuilderHelper.php
+++ b/View/Helper/MenuBuilderHelper.php
@@ -279,7 +279,7 @@ class MenuBuilderHelper extends AppHelper {
 				}
 			}
 
-			$urlOptions = array('title' => $item['title']);
+			$urlOptions = array('title' => trim(html_entity_decode(strip_tags($item['title'])), chr(0xC2).chr(0xA0)));
 			if (!empty($item['target'])) {
 				$urlOptions['target'] = $item['target'];
 			}


### PR DESCRIPTION
Small fix to link title attribute that clears this attribute from undesirable characters. This is useful for eg. when you're using links with HTML entities in their name or you try to use icon for libs like Font Awesome (check examples: http://fortawesome.github.io/Font-Awesome/examples/).

This fix strip HTML tags, decode entities and remove unnecessary whitespaces (especially non-breaking spaces).

Important: it only strips from this yellow popup (title attribute link of `<a>`) not from the link text itself!
